### PR TITLE
P-234 feat: use EIP1559 instead of legacy tx

### DIFF
--- a/chains/ethereum/chain.go
+++ b/chains/ethereum/chain.go
@@ -114,7 +114,7 @@ func InitializeChain(chainCfg *core.ChainConfig, logger log15.Logger, sysErr cha
 	}
 
 	stop := make(chan int)
-	conn := connection.NewConnection(cfg.endpoint, cfg.http, kp, logger, cfg.gasLimit, cfg.maxGasPrice, cfg.gasMultiplier)
+	conn := connection.NewConnection(cfg.endpoint, cfg.http, kp, logger, cfg.gasLimit, cfg.maxGasPrice, cfg.gasMultiplier, cfg.gasFeeCap, cfg.gasTipCap)
 	err = conn.Connect()
 	if err != nil {
 		return nil, err

--- a/chains/ethereum/config.go
+++ b/chains/ethereum/config.go
@@ -16,6 +16,8 @@ import (
 
 const DefaultGasLimit = 6721975
 const DefaultGasPrice = 20000000000
+const DefaultGasFeeCap = 60000000000 // 60 GWEI
+const DefaultGasTipCap = 5000000000 // 5 GWEI
 const DefaultBlockConfirmations = 10
 const DefaultGasMultiplier = 1
 
@@ -75,8 +77,8 @@ func parseChainConfig(chainCfg *core.ChainConfig) (*Config, error) {
 		genericHandlerContract: utils.ZeroAddress,
 		gasLimit:               big.NewInt(DefaultGasLimit),
 		maxGasPrice:            big.NewInt(DefaultGasPrice),
-		gasFeeCap:              big.NewInt(DefaultGasPrice), 
-		gasTipCap:              big.NewInt(DefaultGasPrice),
+		gasFeeCap:              big.NewInt(DefaultGasFeeCap), 
+		gasTipCap:              big.NewInt(DefaultGasTipCap),
 		gasMultiplier:          big.NewFloat(DefaultGasMultiplier),
 		http:                   false,
 		startBlock:             big.NewInt(0),

--- a/chains/ethereum/config.go
+++ b/chains/ethereum/config.go
@@ -27,6 +27,8 @@ var (
 	GenericHandlerOpt     = "genericHandler"
 	MaxGasPriceOpt        = "maxGasPrice"
 	GasLimitOpt           = "gasLimit"
+	GasFeeCapOpt          = "gasFeeCap"
+	GasTipCapOpt          = "gasTipCap"
 	GasMultiplier         = "gasMultiplier"
 	HttpOpt               = "http"
 	StartBlockOpt         = "startBlock"
@@ -48,6 +50,8 @@ type Config struct {
 	genericHandlerContract common.Address
 	gasLimit               *big.Int
 	maxGasPrice            *big.Int
+	gasFeeCap              *big.Int
+	gasTipCap              *big.Int
 	gasMultiplier          *big.Float
 	http                   bool // Config for type of connection
 	startBlock             *big.Int
@@ -71,6 +75,8 @@ func parseChainConfig(chainCfg *core.ChainConfig) (*Config, error) {
 		genericHandlerContract: utils.ZeroAddress,
 		gasLimit:               big.NewInt(DefaultGasLimit),
 		maxGasPrice:            big.NewInt(DefaultGasPrice),
+		gasFeeCap:              big.NewInt(DefaultGasPrice), 
+		gasTipCap:              big.NewInt(DefaultGasPrice),
 		gasMultiplier:          big.NewFloat(DefaultGasMultiplier),
 		http:                   false,
 		startBlock:             big.NewInt(0),
@@ -101,6 +107,28 @@ func parseChainConfig(chainCfg *core.ChainConfig) (*Config, error) {
 			delete(chainCfg.Opts, MaxGasPriceOpt)
 		} else {
 			return nil, errors.New("unable to parse max gas price")
+		}
+	}
+
+	if gasFeeCap, ok := chainCfg.Opts[GasFeeCapOpt]; ok {
+		price := big.NewInt(0)
+		_, pass := price.SetString(gasFeeCap, 10)
+		if pass {
+			config.gasFeeCap = price
+			delete(chainCfg.Opts, GasFeeCapOpt)
+		} else {
+			return nil, errors.New("unable to parse gas fee cap")
+		}
+	}
+
+	if gasTipCap, ok := chainCfg.Opts[GasTipCapOpt]; ok {
+		price := big.NewInt(0)
+		_, pass := price.SetString(gasTipCap, 10)
+		if pass {
+			config.gasTipCap = price
+			delete(chainCfg.Opts, GasTipCapOpt)
+		} else {
+			return nil, errors.New("unable to parse gas tip cap")
 		}
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -105,6 +105,7 @@ func GetConfig(ctx *cli.Context) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
+	log.Debug("Config loaded", fig)
 	return &fig, nil
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -105,7 +105,6 @@ func GetConfig(ctx *cli.Context) (*Config, error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Debug("Config loaded", fig)
 	return &fig, nil
 }
 

--- a/connections/ethereum/connection.go
+++ b/connections/ethereum/connection.go
@@ -75,7 +75,7 @@ func (c *Connection) Connect() error {
 	c.conn = ethclient.NewClient(rpcClient)
 
 	// Construct tx opts, call opts, and nonce mechanism
-	opts, _, err := c.newTransactOpts(big.NewInt(0), c.gasFeeCap, c.gasTipCap)
+	opts, _, err := c.newTransactOpts(big.NewInt(0), c.gasFeeCap, c.gasTipCap, c.gasLimit)
 	if err != nil {
 		return err
 	}
@@ -111,7 +111,7 @@ func (c *Connection) Connect() error {
 // }
 
 // newTransactOpts builds the TransactOpts for the connection's keypair.
-func (c *Connection) newTransactOpts(value, gasFeeCap, gasTipCap *big.Int) (*bind.TransactOpts, uint64, error) {
+func (c *Connection) newTransactOpts(value, gasFeeCap, gasTipCap, gasLimit *big.Int) (*bind.TransactOpts, uint64, error) {
 	privateKey := c.kp.PrivateKey()
 	address := ethcrypto.PubkeyToAddress(privateKey.PublicKey)
 
@@ -133,6 +133,7 @@ func (c *Connection) newTransactOpts(value, gasFeeCap, gasTipCap *big.Int) (*bin
 	auth.Nonce = big.NewInt(int64(nonce))
 	auth.Value = value
 	auth.Context = context.Background()
+	auth.GasLimit = uint64(gasLimit.Int64())
 	auth.GasFeeCap = gasFeeCap
 	auth.GasTipCap = gasTipCap
 


### PR DESCRIPTION
 So this PR updates Chainbridge to use `EIP-1559` or Dynamic Fee Calculation Transaction over Legacy Transaction. 
 Some notes: 
 - So the Go Ethereum dependency uses Dynamic Fee Tx only when the respective fields are set that is `GasFeeCap` and `GasTipCap` else it proceeds to use Legacy Transaction - https://github.com/ethereum/go-ethereum/blob/576681f29b895dd39e559b7ba17fcd89b42e4833/accounts/abi/bind/base.go#L285 
 - We cannot set chainbridge to use both Legacy and EIP-1559, It is either this or that - https://github.com/ethereum/go-ethereum/blob/576681f29b895dd39e559b7ba17fcd89b42e4833/accounts/abi/bind/base.go#L229
 - I've updated the parsing logic to look for `GasFeeCap` and `GasTipCap`, And to use these values when setting up the `Ethereum Client` . 
 - I've tested this in `Sepholia Testnet` and you can see the transaction here - https://sepolia.etherscan.io/tx/0xc01c3810732b2b68912b708a16c5e3e94d14b61bcddc4e382aab832bddbac2fd
 - I set the `GasFeeCap` to be `60 GWEI` and the `GasTipCap` to be `5 GWEI` for testing, We can set this according to the bridge fee that is being charged. (can be set in `config.json`)
 - We don't need to use a Live Gas Fees Oracle 
 - I am not sure if the deployed relayers are using `kai` or `minqi` branch. Let me know which branch should I raise this PR to
 - This implementation allows us to not update the `Ethereum` dependencies which has several breaking changes over the last 2 years. 
 